### PR TITLE
Comply with StyleCop, fix UnityEditor namespace issues

### DIFF
--- a/Assets/RedBlueGames/NotNullAttribute/Editor/FindNotNullsOnLaunch.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/Editor/FindNotNullsOnLaunch.cs
@@ -1,21 +1,28 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Collections;
+﻿namespace RedBlueGames.NotNull
+{
+    using System.Collections;
+    using UnityEditor;
+    using UnityEngine;
 
-[InitializeOnLoad]
-public class FindNotNullsOnLaunch {
-	
-	static FindNotNullsOnLaunch ()
-	{
-		if(Debug.isDebugBuild) {
-			// Searching on first launch seemed to execute before references were wired up on scene objects.
-			EditorApplication.update += RunOnce;
-		}
-	}
+    /// <summary>
+    /// Class that contains logic to find NotNull violations when pressing Play from the Editor
+    /// </summary>
+    [InitializeOnLoad]
+    public class FindNotNullsOnLaunch
+    {
+        static FindNotNullsOnLaunch()
+        {
+            if (Debug.isDebugBuild)
+            {
+                // Searching on first launch seemed to execute before references were wired up on scene objects.
+                EditorApplication.update += RunOnce;
+            }
+        }
 
-	static void RunOnce ()
-	{
-		EditorApplication.update -= RunOnce;
-		RedBlueGames.NotNull.NotNullFinder.SearchForAndErrorForNotNullViolations ();
-	}
+        private static void RunOnce()
+        {
+            EditorApplication.update -= RunOnce;
+            RedBlueGames.NotNull.NotNullFinder.SearchForAndErrorForNotNullViolations();
+        }
+    }
 }

--- a/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullAttributeDrawer.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullAttributeDrawer.cs
@@ -1,0 +1,130 @@
+﻿namespace RedBlueGames.NotNull
+{
+    using UnityEditor;
+    using UnityEngine;
+
+    /// <summary>
+    /// Drawerer for fields with NotNullAttribute assigned.
+    /// </summary>
+    [CustomPropertyDrawer(typeof(NotNullAttribute))]
+    public class NotNullAttributeDrawer : PropertyDrawer
+    {
+        private int warningHeight = 30;
+
+        /// <summary>
+        /// Gets the height that is passed into the rect in OnGUI.
+        /// </summary>
+        /// <returns>The property height.</returns>
+        /// <param name="property">Serialized property.</param>
+        /// <param name="label">Label for the property.</param>
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            // The height for the object assignment is just whatever Unity would
+            // do by default.
+            float objectReferenceHeight = base.GetPropertyHeight(property, label);
+            float calculatedHeight = objectReferenceHeight;
+
+            bool shouldAddWarningHeight = property.propertyType != SerializedPropertyType.ObjectReference ||
+                                          this.IsNotWiredUp(property);
+            if (shouldAddWarningHeight)
+            {
+                // When it's not wired up we add in additional height for the warning text.
+                calculatedHeight += this.warningHeight;
+            }
+
+            return calculatedHeight;
+        }
+
+        /// <summary>
+        /// Raises the GUI event and draws the property.
+        /// </summary>
+        /// <param name="position">Position for the property.</param>
+        /// <param name="property">Serialized property.</param>
+        /// <param name="label">Label for the property.</param>
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            // Position is the DrawArea of the property to be rendered. Includes height from GetHeight()
+            // BeginProperty used for objects that don't handle [SerializeProperty] attribute.
+            EditorGUI.BeginProperty(position, label, property);
+
+            // Calculate ObjectReference rect size
+            Rect objectReferenceRect = position;
+
+            // Use Unity's default height calculation for the reference rectangle
+            float objectReferenceHeight = base.GetPropertyHeight(property, label);
+            objectReferenceRect.height = objectReferenceHeight;
+            this.BuildObjectField(objectReferenceRect, property, label);
+
+            // Calculate warning rectangle's size
+            Rect warningRect = new Rect(
+                                   position.x,
+                                   objectReferenceRect.y + objectReferenceHeight, 
+                                   position.width,
+                                   this.warningHeight);
+            this.BuildWarningRectangle(warningRect, property);
+
+            EditorGUI.EndProperty();
+        }
+
+        private bool IsNotWiredUp(SerializedProperty property)
+        {
+            if (this.IsPropertyNotNullInSceneAndPrefab(property))
+            {
+                return false;
+            }
+            else
+            {
+                return property.objectReferenceValue == null;
+            }
+        }
+
+        private bool IsPropertyNotNullInSceneAndPrefab(SerializedProperty property)
+        {
+            NotNullAttribute myAttribute = (NotNullAttribute)this.attribute;
+            bool isPrefabAllowedNull = myAttribute.IgnorePrefab;
+            return this.IsPropertyOnPrefab(property) && isPrefabAllowedNull;
+        }
+
+        private bool IsPropertyOnPrefab(SerializedProperty property)
+        {
+            return EditorUtility.IsPersistent(property.serializedObject.targetObject);
+        }
+
+        private void BuildObjectField(Rect drawArea, SerializedProperty property, GUIContent label)
+        {   
+            if (property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                EditorGUI.PropertyField(drawArea, property, label);
+                return;
+            }
+
+            if (this.IsPropertyNotNullInSceneAndPrefab(property))
+            {
+                // Render Object Field for NotNull (InScene) attributes on Prefabs.
+                label.text = "(*) " + label.text;
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUI.ObjectField(drawArea, property, label);
+                EditorGUI.EndDisabledGroup();
+            }
+            else
+            {
+                label.text = "* " + label.text;
+                EditorGUI.ObjectField(drawArea, property, label);
+            }
+        }
+
+        private void BuildWarningRectangle(Rect drawArea, SerializedProperty property)
+        {
+            if (property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                string warningString = "NotNullAttribute only valid on ObjectReference fields.";
+                EditorGUI.HelpBox(drawArea, warningString, MessageType.Warning);
+            }
+            else if (this.IsNotWiredUp(property))
+            {
+                string warningString = "Missing object reference for NotNull property.";
+                EditorGUI.HelpBox(drawArea, warningString, MessageType.Error);
+            }
+        }
+    }
+}

--- a/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullAttributeDrawer.cs.meta
+++ b/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullAttributeDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 427b9929a936844b2a6a8e9610ca400c
+timeCreated: 1460386995
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullFinder.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/Editor/NotNullFinder.cs
@@ -1,64 +1,80 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Reflection;
-using System.Collections;
-using System.Collections.Generic;
-using RedBlueGames.NotNull;
-
-namespace RedBlueGames.NotNull
+﻿namespace RedBlueGames.NotNull
 {
-	public class NotNullFinder : EditorWindow
-	{
-		static bool outputLogs = false;
-		
-		[MenuItem ("RedBlueTools/Not Null Finder")]
-		public static void SearchForAndErrorForNotNullViolations ()
-		{
-			Debug.Log ("Searching for null NotNull fields");
-			// Search for and error for prefabs with null RequireWire fields
-			string[] guidsForAllGameObjects = AssetDatabase.FindAssets ("t:GameObject");
-			foreach (string guid in guidsForAllGameObjects) {
-				Log ("Loading GUID: " + guid);
-				string pathToGameObject = AssetDatabase.GUIDToAssetPath (guid);
-				Log ("Loading Asset for guid at path: " + pathToGameObject);
-				GameObject gameObject = (GameObject)AssetDatabase.LoadAssetAtPath (pathToGameObject, typeof(GameObject));
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using RedBlueGames.NotNull;
+    using UnityEditor;
+    using UnityEngine;
 
-				ErrorForNullRequiredWiresOnGameObject (gameObject, pathToGameObject);
-			}
+    /// <summary>
+    /// NotNullFinder fires off checks for NotNull violations in the scene and asset database
+    /// and reports their errors.
+    /// </summary>
+    public class NotNullFinder : EditorWindow
+    {
+        private static bool outputLogs = false;
 
-			// Search the scene objects (only need root game objects since children will be searched)
-			GameObject[] sceneGameObjects = (GameObject[])GameObject.FindObjectsOfType (typeof(GameObject));
-			List<GameObject> rootSceneGameObjects = new List<GameObject> ();
-			foreach (GameObject sceneGameObject in sceneGameObjects) {
-				if (sceneGameObject.transform.parent == null) {
-					rootSceneGameObjects.Add (sceneGameObject);
-				}
-			}
-			foreach (GameObject rootGameObjectInScene in rootSceneGameObjects) {
-				ErrorForNullRequiredWiresOnGameObject (rootGameObjectInScene, "In current scene.");
-			}
+        /// <summary>
+        /// Searchs for and error for not null violations in the scene and asset database
+        /// </summary>
+        [MenuItem("RedBlueTools/Not Null Finder")]
+        public static void SearchForAndErrorForNotNullViolations()
+        {
+            // Debug.Log ("Searching for null NotNull fields");
+            // Search for and error for prefabs with null RequireWire fields
+            string[] guidsForAllGameObjects = AssetDatabase.FindAssets("t:GameObject");
+            foreach (string guid in guidsForAllGameObjects)
+            {
+                Log("Loading GUID: " + guid);
+                string pathToGameObject = AssetDatabase.GUIDToAssetPath(guid);
+                Log("Loading Asset for guid at path: " + pathToGameObject);
+                GameObject gameObject = (GameObject)AssetDatabase.LoadAssetAtPath(pathToGameObject, typeof(GameObject));
 
-			Debug.Log ("NotNull search complete");
-		}
+                ErrorForNullRequiredWiresOnGameObject(gameObject, pathToGameObject);
+            }
 
-		static void ErrorForNullRequiredWiresOnGameObject (GameObject gameObject, string pathToAsset)
-		{
-			List<NotNullViolation> errorsOnGameObject = NotNullChecker.FindErroringFields (gameObject);
-			foreach (NotNullViolation violation in errorsOnGameObject) {
-				Debug.LogError (violation + "\nPath: " + pathToAsset, violation.ErrorGameObject);
-			}
+            // Search the scene objects (only need root game objects since children will be searched)
+            GameObject[] sceneGameObjects = (GameObject[])GameObject.FindObjectsOfType(typeof(GameObject));
+            List<GameObject> rootSceneGameObjects = new List<GameObject>();
+            foreach (GameObject sceneGameObject in sceneGameObjects)
+            {
+                if (sceneGameObject.transform.parent == null)
+                {
+                    rootSceneGameObjects.Add(sceneGameObject);
+                }
+            }
 
-			foreach (Transform child in gameObject.transform) {
-				ErrorForNullRequiredWiresOnGameObject (child.gameObject, pathToAsset);
-			}
-		}
+            foreach (GameObject rootGameObjectInScene in rootSceneGameObjects)
+            {
+                ErrorForNullRequiredWiresOnGameObject(rootGameObjectInScene, "In current scene.");
+            }
 
-		static void Log (string log)
-		{
-			if (outputLogs == false) {
-				return;
-			}
-			Debug.Log (log);
-		}
-	}
+            // Debug.Log ("NotNull search complete");
+        }
+
+        private static void ErrorForNullRequiredWiresOnGameObject(GameObject gameObject, string pathToAsset)
+        {
+            List<NotNullViolation> errorsOnGameObject = NotNullChecker.FindErroringFields(gameObject);
+            foreach (NotNullViolation violation in errorsOnGameObject)
+            {
+                Debug.LogError(violation + "\nPath: " + pathToAsset, violation.ErrorGameObject);
+            }
+
+            foreach (Transform child in gameObject.transform)
+            {
+                ErrorForNullRequiredWiresOnGameObject(child.gameObject, pathToAsset);
+            }
+        }
+
+        private static void Log(string log)
+        {
+            if (outputLogs == false)
+            {
+                return;
+            }
+
+            Debug.Log(log);
+        }
+    }
 }

--- a/Assets/RedBlueGames/NotNullAttribute/NotNullAttribute.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/NotNullAttribute.cs
@@ -1,112 +1,16 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System;
-using System.Reflection;
+﻿using System;
+using UnityEngine;
 
-[System.AttributeUsage (System.AttributeTargets.Field)]
+/// <summary>
+/// Not Null Attribute will error in the Editor if an object field has not been assigned.
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field)]
 public class NotNullAttribute : PropertyAttribute
 {
-
-	public bool IgnorePrefab = false;
+    /// <summary>
+    /// Gets or sets a value indicating whether this <see cref="NotNullAttribute"/> should ignore prefabs.
+    /// Use this when your object reqiures a reference to an object in the scene, such as a spawn point.
+    /// </summary>
+    /// <value><c>true</c> if ignore prefab; otherwise, <c>false</c>.</value>
+    public bool IgnorePrefab { get; set; }
 }
-
-#if UNITY_EDITOR
-namespace RedBlueGames.NotNull
-{
-	[CustomPropertyDrawer(typeof(NotNullAttribute))]
-	public class NotNullAttributeDrawer : PropertyDrawer
-	{
-		int warningHeight = 30;
-		
-		// Returns the height that is passed into the rect in OnGUI
-		public override float GetPropertyHeight (SerializedProperty property, GUIContent label)
-		{
-			// The height for the object assignment is just whatever Unity would
-			// do by default.
-			float objectReferenceHeight = base.GetPropertyHeight (property, label);
-			float calculatedHeight = objectReferenceHeight;
-			
-			bool shouldAddWarningHeight = property.propertyType != SerializedPropertyType.ObjectReference ||
-				IsNotWiredUp (property);
-			if (shouldAddWarningHeight) {
-				// When it's not wired up we add in additional height for the warning text.
-				calculatedHeight += warningHeight;
-			}
-			
-			return calculatedHeight;
-		}
-		
-		bool IsNotWiredUp (SerializedProperty property)
-		{
-			if (IsPropertyNotNullInSceneAndPrefab (property)) {
-				return false;
-			} else {
-				return property.objectReferenceValue == null;
-			}
-		}
-		
-		bool IsPropertyNotNullInSceneAndPrefab (SerializedProperty property)
-		{
-			NotNullAttribute myAttribute = (NotNullAttribute)base.attribute;
-			bool isPrefabAllowedNull = myAttribute.IgnorePrefab;
-			return IsPropertyOnPrefab (property) && isPrefabAllowedNull;
-		}
-		
-		bool IsPropertyOnPrefab (SerializedProperty property)
-		{
-			return EditorUtility.IsPersistent (property.serializedObject.targetObject);
-		}
-		
-		public override void OnGUI (Rect position, SerializedProperty property, GUIContent label)
-		{
-			// Position is the DrawArea of the property to be rendered. Includes height from GetHeight()
-			// BeginProperty used for objects that don't handle [SerializeProperty] attribute.
-			EditorGUI.BeginProperty (position, label, property);
-			
-			// Calculate ObjectReference rect size
-			Rect objectReferenceRect = position;
-			// Use Unity's default height calculation for the reference rectangle
-			float objectReferenceHeight = base.GetPropertyHeight (property, label);
-			objectReferenceRect.height = objectReferenceHeight;
-			BuildObjectField (objectReferenceRect, property, label);
-			
-			// Calculate warning rectangle's size
-			Rect warningRect = new Rect (position.x, objectReferenceRect.y + objectReferenceHeight, 
-			                             position.width, warningHeight);
-			BuildWarningRectangle (warningRect, property);
-			
-			EditorGUI.EndProperty ();
-		}
-		
-		void BuildObjectField (Rect drawArea, SerializedProperty property, GUIContent label)
-		{	
-			if (property.propertyType != SerializedPropertyType.ObjectReference) {
-				EditorGUI.PropertyField (drawArea, property, label);
-				return;
-			}
-			
-			if (IsPropertyNotNullInSceneAndPrefab (property)) {
-				// Render Object Field for NotNull (InScene) attributes on Prefabs.
-				label.text = "(*) " + label.text;
-				EditorGUI.BeginDisabledGroup (true);
-				EditorGUI.ObjectField (drawArea, property, label);
-				EditorGUI.EndDisabledGroup ();
-			} else {
-				label.text = "* " + label.text;
-				EditorGUI.ObjectField (drawArea, property, label);
-			}
-		}
-		
-		void BuildWarningRectangle (Rect drawArea, SerializedProperty property)
-		{
-			if (property.propertyType != SerializedPropertyType.ObjectReference) {
-				string warningString = "NotNullAttribute only valid on ObjectReference fields.";
-				EditorGUI.HelpBox (drawArea, warningString, MessageType.Warning);
-			} else if (IsNotWiredUp (property)) {
-				string warningString = "Missing object reference for NotNull property.";
-				EditorGUI.HelpBox (drawArea, warningString, MessageType.Error);
-			}
-		}
-	}
-}
-#endif

--- a/Assets/RedBlueGames/NotNullAttribute/NotNullChecker.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/NotNullChecker.cs
@@ -1,82 +1,103 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
-using System;
-using RedBlueGames.Tools;
-
-namespace RedBlueGames.NotNull
+﻿namespace RedBlueGames.NotNull
 {
-	public class NotNullChecker
-	{
-		public static List<NotNullViolation> FindErroringFields (GameObject sourceObject)
-		{
-			List<NotNullViolation> erroringFields = new List<NotNullViolation> ();
-			MonoBehaviour[] monobehaviours = sourceObject.GetComponents<MonoBehaviour> ();
-			for (int i = 0; i < monobehaviours.Length; i++) {
-				try {
-					if (MonoBehaviourHasErrors (monobehaviours [i])) {
-						List<NotNullViolation> violationsOnMonoBehaviour = FindErroringFields (monobehaviours [i]);
-						erroringFields.AddRange (violationsOnMonoBehaviour);
-					}
-				} catch (System.ArgumentNullException) {
-					// TODO: Handle missing monobehaviours
-				}
-			}
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using RedBlueGames.Tools;
+    using UnityEditor;
+    using UnityEngine;
 
-			return erroringFields;
-		}
+    /// <summary>
+    /// This class is responsible for checking objects for NotNull violations.
+    /// </summary>
+    public class NotNullChecker
+    {
+        /// <summary>
+        /// Finds the erroring NotNull fields on a GameObject.
+        /// </summary>
+        /// <returns>The erroring fields.</returns>
+        /// <param name="sourceObject">Source object.</param>
+        public static List<NotNullViolation> FindErroringFields(GameObject sourceObject)
+        {
+            List<NotNullViolation> erroringFields = new List<NotNullViolation>();
+            MonoBehaviour[] monobehaviours = sourceObject.GetComponents<MonoBehaviour>();
+            for (int i = 0; i < monobehaviours.Length; i++)
+            {
+                try
+                {
+                    if (MonoBehaviourHasErrors(monobehaviours[i]))
+                    {
+                        List<NotNullViolation> violationsOnMonoBehaviour = FindErroringFields(monobehaviours[i]);
+                        erroringFields.AddRange(violationsOnMonoBehaviour);
+                    }
+                }
+                catch (System.ArgumentNullException)
+                {
+                    // TODO: Handle missing monobehaviours
+                }
+            }
 
-		static List<NotNullViolation> FindErroringFields (MonoBehaviour sourceMB)
-		{
-			if (sourceMB == null) {
-				throw new System.ArgumentNullException ("MonoBehaviour is null. It likely references" +
-					" a script that's been deleted.");
-			}
+            return erroringFields;
+        }
 
-			List<NotNullViolation> erroringFields = new List<NotNullViolation> ();
-		
-			// Add null NotNull fields
-			List<FieldInfo> notNullFields = 
-				ReflectionUtility.GetFieldsWithAttributeFromType<NotNullAttribute> (sourceMB.GetType ());
-			foreach (FieldInfo notNullField in notNullFields) {
-				object fieldObject = notNullField.GetValue (sourceMB);
-				if (fieldObject == null || fieldObject.Equals (null)) {
-					erroringFields.Add (new NotNullViolation (notNullField, sourceMB));
-				}
-			}
-		
-			// Remove NotNullViolations for prefabs with IgnorePrefab
-			#if UNITY_EDITOR
-			bool isObjectAPrefab = PrefabUtility.GetPrefabType(sourceMB.gameObject) == PrefabType.Prefab;
-			List<NotNullViolation> violationsToIgnore = new List<NotNullViolation> ();
-			if (isObjectAPrefab) {
-				// Find all violations that should be overlooked.
-				foreach (NotNullViolation errorField in erroringFields) {
-					FieldInfo fieldInfo = errorField.FieldInfo;
-					foreach (Attribute attribute in Attribute.GetCustomAttributes (fieldInfo)) {
-						if (attribute.GetType () == typeof(NotNullAttribute)) {
-							if (((NotNullAttribute)attribute).IgnorePrefab) {
-								violationsToIgnore.Add (errorField);
-							}
-						}
-					}
-				}
+        private static List<NotNullViolation> FindErroringFields(MonoBehaviour sourceMB)
+        {
+            if (sourceMB == null)
+            {
+                throw new System.ArgumentNullException("MonoBehaviour is null. It likely references" +
+                    " a script that's been deleted.");
+            }
 
-				foreach (NotNullViolation violation in violationsToIgnore) {
-					erroringFields.Remove (violation);
-				}
-			}
-			#endif
-		
-			return erroringFields;
-		}
-	
-		static bool MonoBehaviourHasErrors (MonoBehaviour mb)
-		{
-			return FindErroringFields (mb).Count > 0;
-		}
-	}
+            List<NotNullViolation> erroringFields = new List<NotNullViolation>();
 
+            // Add null NotNull fields
+            List<FieldInfo> notNullFields = 
+                ReflectionUtility.GetFieldsWithAttributeFromType<NotNullAttribute>(
+                    sourceMB.GetType(),
+                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            foreach (FieldInfo notNullField in notNullFields)
+            {
+                object fieldObject = notNullField.GetValue(sourceMB);
+                if (fieldObject == null || fieldObject.Equals(null))
+                {
+                    erroringFields.Add(new NotNullViolation(notNullField, sourceMB));
+                }
+            }
+
+            // Remove NotNullViolations for prefabs with IgnorePrefab
+            bool isObjectAPrefab = PrefabUtility.GetPrefabType(sourceMB.gameObject) == PrefabType.Prefab;
+            List<NotNullViolation> violationsToIgnore = new List<NotNullViolation>();
+            if (isObjectAPrefab)
+            {
+                // Find all violations that should be overlooked.
+                foreach (NotNullViolation errorField in erroringFields)
+                {
+                    FieldInfo fieldInfo = errorField.FieldInfo;
+                    foreach (Attribute attribute in Attribute.GetCustomAttributes(fieldInfo))
+                    {
+                        if (attribute.GetType() == typeof(NotNullAttribute))
+                        {
+                            if (((NotNullAttribute)attribute).IgnorePrefab)
+                            {
+                                violationsToIgnore.Add(errorField);
+                            }
+                        }
+                    }
+                }
+
+                foreach (NotNullViolation violation in violationsToIgnore)
+                {
+                    erroringFields.Remove(violation);
+                }
+            }
+
+            return erroringFields;
+        }
+
+        private static bool MonoBehaviourHasErrors(MonoBehaviour mb)
+        {
+            return FindErroringFields(mb).Count > 0;
+        }
+    }
 }

--- a/Assets/RedBlueGames/NotNullAttribute/NotNullViolation.cs
+++ b/Assets/RedBlueGames/NotNullAttribute/NotNullViolation.cs
@@ -1,40 +1,75 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
-using System.Reflection;
-using System;
-
-namespace RedBlueGames.NotNull
+﻿namespace RedBlueGames.NotNull
 {
-	public class NotNullViolation
-	{
-		public FieldInfo FieldInfo;
-		public GameObject ErrorGameObject;
-		public MonoBehaviour SourceMonoBehaviour;
-		
-		public string FullName {
-			get {
-				Transform currentParent = ErrorGameObject.transform.parent;
-				string fullName = ErrorGameObject.name;
-				while (currentParent != null) {
-					fullName = currentParent.gameObject.name + "/" + fullName;
-					currentParent = currentParent.transform.parent;
-				}
-				return fullName;
-			}
-		}
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using UnityEngine;
 
-		
-		public NotNullViolation (FieldInfo fieldInfo, MonoBehaviour sourceMB)
-		{
-			this.FieldInfo = fieldInfo;
-			this.SourceMonoBehaviour = sourceMB;
-			this.ErrorGameObject = sourceMB.gameObject;
-		}
+    /// <summary>
+    /// Not null violation represents data for objects that do not have their required (NotNull) fields
+    /// assigned.
+    /// </summary>
+    public class NotNullViolation
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedBlueGames.NotNull.NotNullViolation"/> class.
+        /// </summary>
+        /// <param name="fieldInfo">Field info that describes the NotNull field.</param>
+        /// <param name="sourceMB">Source MonoBehavior that contains the field.</param>
+        public NotNullViolation(FieldInfo fieldInfo, MonoBehaviour sourceMB)
+        {
+            this.FieldInfo = fieldInfo;
+            this.SourceMonoBehaviour = sourceMB;
+            this.ErrorGameObject = sourceMB.gameObject;
+        }
 
-		public override string ToString ()
-		{
-			return string.Format ("[NotNullViolation: Field={0}, FullName={1}]", FieldInfo.Name, FullName);
-		}
-	}
+        /// <summary>
+        /// Gets or sets the field info associated with the NotNull attribute.
+        /// </summary>
+        /// <value>The field info.</value>
+        public FieldInfo FieldInfo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the game object that contains the component with the violation.
+        /// </summary>
+        /// <value>The erroring game object.</value>
+        public GameObject ErrorGameObject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MonoBehavior that contains the violation.
+        /// </summary>
+        /// <value>The source mono behaviour.</value>
+        public MonoBehaviour SourceMonoBehaviour { get; set; }
+
+        /// <summary>
+        /// Gets the full path to the erroring game object, including parents.
+        /// </summary>
+        /// <value>The full name.</value>
+        public string FullName
+        {
+            get
+            {
+                Transform currentParent = this.ErrorGameObject.transform.parent;
+                string fullName = this.ErrorGameObject.name;
+                while (currentParent != null)
+                {
+                    fullName = currentParent.gameObject.name + "/" + fullName;
+                    currentParent = currentParent.transform.parent;
+                }
+
+                return fullName;
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the current 
+        /// <see cref="RedBlueGames.NotNull.NotNullViolation"/>.
+        /// </summary>
+        /// <returns>A <see cref="System.String"/> that represents the current 
+        /// <see cref="RedBlueGames.NotNull.NotNullViolation"/>.</returns>
+        public override string ToString()
+        {
+            return string.Format("[NotNullViolation: Field={0}, FullName={1}]", this.FieldInfo.Name, this.FullName);
+        }
+    }
 }
-


### PR DESCRIPTION
This is an import of NotNullAttribute as it exists in our current working
projects. This import brings it into compliance with StyleCop and splits out
Editor classes into their own classes. It also better handles namespacing.
